### PR TITLE
[ZYNQ-09] ZYNQ-09: PTY binding for Claude, input forwarding

### DIFF
--- a/images/claude/Dockerfile
+++ b/images/claude/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:22-bookworm-slim
+
+# Install Claude Code CLI globally
+RUN npm install -g @anthropic-ai/claude-code && \
+    npm cache clean --force
+
+# Install common tools Claude Code needs
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        curl \
+        ca-certificates \
+        jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create workspace directory
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# Keep container alive for exec
+CMD ["sleep", "infinity"]

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -9,6 +9,9 @@ import (
 
 // AgentAdapter launches and manages an agent CLI inside a container.
 type AgentAdapter interface {
+	// Image returns the Docker image required for this agent.
+	Image() string
+
 	// Start launches the agent process inside the container.
 	// Returns a PTYConn connected to the agent's stdin/stdout.
 	Start(ctx context.Context, containerID string) (sandbox.PTYConn, error)

--- a/internal/adapter/claude.go
+++ b/internal/adapter/claude.go
@@ -9,6 +9,8 @@ import (
 	"github.com/Rsych/zynqel-core/internal/shortid"
 )
 
+const claudeImage = "zynqel-claude:latest"
+
 // ClaudeAdapter launches the Claude CLI inside a container.
 type ClaudeAdapter struct {
 	sb   sandbox.Sandbox
@@ -19,6 +21,11 @@ type ClaudeAdapter struct {
 // NewClaudeAdapter creates a new ClaudeAdapter.
 func NewClaudeAdapter(sb sandbox.Sandbox) *ClaudeAdapter {
 	return &ClaudeAdapter{sb: sb}
+}
+
+// Image returns the Docker image with Claude Code pre-installed.
+func (a *ClaudeAdapter) Image() string {
+	return claudeImage
 }
 
 // Start launches the Claude CLI via docker exec with a PTY.

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -71,7 +71,7 @@ func (d *DockerSandbox) Create(ctx context.Context, spec Spec) (string, error) {
 		Labels:    labels,
 		Tty:       true,
 		OpenStdin: true,
-		Cmd:       []string{"/bin/sh"},
+		Cmd:       spec.Cmd, // nil = use image CMD
 	}
 
 	hostConfig := &container.HostConfig{}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -35,6 +35,7 @@ type PTYConn interface {
 // container config.
 type Spec struct {
 	Image       string            // Docker image to run
+	Cmd         []string          // Command to run (nil = use image default)
 	Env         map[string]string // Environment variables
 	Labels      map[string]string // Container labels for identification
 	MemoryBytes int64             // Memory limit in bytes (0 = no limit)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -48,8 +48,20 @@ func (m *Manager) Create(ctx context.Context, spec SessionSpec) (*Session, error
 		spec.Env = make(map[string]string)
 	}
 
+	// Use the adapter's image if one is configured, otherwise default shell.
+	img := defaultImage
+	var cmd []string
+	if agentAdapter != nil {
+		img = agentAdapter.Image()
+		// Adapter sessions use the image's default CMD (e.g. sleep infinity).
+		// The agent runs via Exec after the container is up.
+	} else {
+		cmd = []string{"/bin/sh"}
+	}
+
 	sbSpec := sandbox.Spec{
-		Image: defaultImage,
+		Image: img,
+		Cmd:   cmd,
 		Env:   spec.Env,
 		Labels: map[string]string{
 			"zynqel.session-id": id,


### PR DESCRIPTION
## Summary
- ZYNQ-09: PTY binding for Claude, input forwarding

## Validation
- [ ] `go build ./...`
- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] local verification completed

## Linked
- Closes #12

## Project
- [ ] Project item is linked
- [ ] Status is `In Progress` while review is open
