### PR TITLE
feat: dev console improvements — image selector, PTY resize, Tab fix

### DIFF
--- a/images/qwen/Dockerfile
+++ b/images/qwen/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:22-bookworm-slim
+
+# Install Qwen Code CLI globally
+RUN npm install -g @qwen-code/qwen-code@latest && \
+    npm cache clean --force
+
+# Install common tools
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        curl \
+        ca-certificates \
+        jq \
+        procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create workspace directory
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# Keep container alive for exec
+CMD ["sleep", "infinity"]

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -232,6 +232,14 @@ func (d *DockerSandbox) ExecRun(ctx context.Context, id string, cmd []string) ([
 	return output, nil
 }
 
+// Resize changes the TTY dimensions of a running container.
+func (d *DockerSandbox) Resize(ctx context.Context, id string, cols, rows int) error {
+	return d.cli.ContainerResize(ctx, id, container.ResizeOptions{
+		Width:  uint(cols),
+		Height: uint(rows),
+	})
+}
+
 func (d *DockerSandbox) Close() error {
 	return d.cli.Close()
 }

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -21,6 +21,7 @@ type Sandbox interface {
 	Attach(ctx context.Context, id string) (PTYConn, error)
 	Exec(ctx context.Context, id string, cmd []string) (PTYConn, error)
 	ExecRun(ctx context.Context, id string, cmd []string) ([]byte, error)
+	Resize(ctx context.Context, id string, cols, rows int) error
 }
 
 // PTYConn is a bidirectional connection to a container's PTY.

--- a/internal/server/ws.go
+++ b/internal/server/ws.go
@@ -130,6 +130,18 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 				log.Printf("pty write error for session %s: %v", id, err)
 				return
 			}
+		case "pty.resize":
+			var size struct {
+				Cols int `json:"cols"`
+				Rows int `json:"rows"`
+			}
+			if err := json.Unmarshal(msg.Data, &size); err != nil {
+				log.Printf("invalid pty.resize data: %v", err)
+				continue
+			}
+			if size.Cols > 0 && size.Rows > 0 {
+				s.sessions.Resize(id, size.Cols, size.Rows)
+			}
 		case "intercept.response":
 			var resp interceptResponse
 			if err := json.Unmarshal(msg.Data, &resp); err != nil {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -68,15 +68,16 @@ func (m *Manager) Create(ctx context.Context, spec SessionSpec) (*Session, error
 		spec.Env = make(map[string]string)
 	}
 
-	// Use the adapter's image if one is configured, otherwise default shell.
+	// Image priority: spec.Image > adapter.Image() > defaultImage
 	img := defaultImage
 	var cmd []string
 	if agentAdapter != nil {
 		img = agentAdapter.Image()
-		// Adapter sessions use the image's default CMD (e.g. sleep infinity).
-		// The agent runs via Exec after the container is up.
 	} else {
 		cmd = []string{"/bin/sh"}
+	}
+	if spec.Image != "" {
+		img = spec.Image
 	}
 
 	sbSpec := sandbox.Spec{
@@ -260,6 +261,21 @@ func (m *Manager) WriteInput(id string, data []byte) error {
 	}
 
 	return s.broadcaster.Write(data)
+}
+
+// Resize updates the PTY dimensions for the session's container.
+func (m *Manager) Resize(id string, cols, rows int) {
+	m.mu.RLock()
+	s, ok := m.sessions[id]
+	m.mu.RUnlock()
+
+	if !ok || s.Status != StatusRunning {
+		return
+	}
+
+	if err := m.sandbox.Resize(context.Background(), s.ContainerID, cols, rows); err != nil {
+		log.Printf("warning: failed to resize session %s: %v", id, err)
+	}
 }
 
 // Shutdown stops and removes all active sessions.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -24,7 +24,8 @@ const (
 // Think of it as the "desired state" for a session.
 // The actual running state lives in Session.
 type SessionSpec struct {
-	Agent   string            `json:"agent"` // e.g. "claude", "cursor", "shell"
+	Agent   string            `json:"agent"`           // e.g. "claude", "cursor", "shell"
+	Image   string            `json:"image,omitempty"` // custom Docker image (overrides agent default)
 	RepoURL string            `json:"repo_url,omitempty"`
 	Branch  string            `json:"branch,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`

--- a/web/console.js
+++ b/web/console.js
@@ -4,6 +4,7 @@
   "use strict";
 
   const selectEl = document.getElementById("session-select");
+  const imageSelect = document.getElementById("image-select");
   const btnCreate = document.getElementById("btn-create");
   const btnKill = document.getElementById("btn-kill");
   const btnRefresh = document.getElementById("btn-refresh");
@@ -24,7 +25,39 @@
   term.open(document.getElementById("terminal-container"));
   fitAddon.fit();
 
-  window.addEventListener("resize", () => fitAddon.fit());
+  // Prevent browser from capturing Tab, Ctrl+C, etc.
+  term.attachCustomKeyEventHandler(function (event) {
+    // Let browser handle Ctrl+Shift+I (dev tools) and F12
+    if ((event.ctrlKey && event.shiftKey && event.key === "I") || event.key === "F12") {
+      return false;
+    }
+    // Prevent browser Tab focus switching — send to terminal instead.
+    if (event.key === "Tab") {
+      event.preventDefault();
+    }
+    return true;
+  });
+
+  // Debounced resize to prevent flickering.
+  let resizeTimer = null;
+  function debouncedFit() {
+    if (resizeTimer) clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function () {
+      fitAddon.fit();
+      sendResize();
+    }, 100);
+  }
+
+  // Send terminal dimensions to the container PTY.
+  function sendResize() {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({
+      type: "pty.resize",
+      data: { cols: term.cols, rows: term.rows },
+    }));
+  }
+
+  window.addEventListener("resize", debouncedFit);
 
   let ws = null;
   let currentSessionId = null;
@@ -60,11 +93,19 @@
     return res.json();
   }
 
+  const imageConfigs = {
+    shell:  { agent: "shell" },
+    claude: { agent: "claude" },
+    qwen:   { agent: "shell", image: "zynqel-qwen:latest" },
+  };
+
   async function createSession() {
+    const selected = imageSelect.value || "shell";
+    const config = imageConfigs[selected] || imageConfigs.shell;
     const res = await apiFetch(apiUrl("/sessions"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ agent: "shell" }),
+      body: JSON.stringify(config),
     });
     return res.json();
   }
@@ -116,13 +157,16 @@
   function connectWS(sessionId) {
     disconnectWS();
     currentSessionId = sessionId;
-    term.clear();
+    term.reset();
     term.focus();
 
     ws = new WebSocket(wsUrl(sessionId));
 
     ws.onopen = function () {
       setStatus(true, "connected");
+      fitAddon.fit();
+      sendResize();
+      term.focus();
     };
 
     ws.onmessage = function (event) {

--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@
     #status .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
     #status .dot.connected { background: #4caf50; }
     #status .dot.disconnected { background: #f44336; }
-    #terminal-container { flex: 1; padding: 4px; position: relative; }
+    #terminal-container { flex: 1; padding: 4px; position: relative; overflow: hidden; }
     #prompt-overlay { position: absolute; bottom: 16px; right: 16px; z-index: 10; display: flex; flex-direction: column; gap: 8px; }
     .prompt-card { background: #16213e; border: 1px solid #0f3460; border-radius: 6px; padding: 10px 14px; max-width: 400px; }
     .prompt-card .prompt-text { font-size: 13px; margin-bottom: 8px; color: #e0e0e0; }
@@ -35,6 +35,11 @@
   <div id="toolbar">
     <h1>Zynqel</h1>
     <select id="session-select"><option value="">-- select session --</option></select>
+    <select id="image-select">
+      <option value="shell">Shell (ubuntu)</option>
+      <option value="claude">Claude Code</option>
+      <option value="qwen">Qwen Code</option>
+    </select>
     <button id="btn-create">Create</button>
     <button id="btn-kill" class="danger">Kill</button>
     <button id="btn-refresh">Refresh</button>


### PR DESCRIPTION
## Summary
- Custom Docker image selection via `spec.Image` field
- Image selector dropdown in dev console (Shell/Claude/Qwen)
- PTY resize support (debounced fit + `pty.resize` WS message + Docker ContainerResize)
- Tab key fix — `preventDefault` stops browser focus switching
- No scrollbars — `overflow: hidden` on terminal container
- Qwen Code Docker image (`images/qwen/Dockerfile`)

## Validation
- [ ] `go build ./...`
- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] local verification completed