### PR TITLE
fix: add CORS headers for dev mode cross-origin requests

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,11 +66,14 @@ func (s *Server) routes(webFS fs.FS) {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// CORS: allow cross-origin requests from localhost dev servers (e.g. Next.js on :3000).
+	// In production, Go serves the static export so all requests are same-origin.
 	origin := r.Header.Get("Origin")
-	if origin != "" {
+	if origin != "" && strings.HasPrefix(origin, "http://localhost") {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Max-Age", "86400")
 	}
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
## Summary
- Add CORS headers in `ServeHTTP` so the Next.js dev server (`:3000`) can make API calls to the Go backend (`:8080`)
- Handles preflight `OPTIONS` requests
- Only affects cross-origin requests (production serves everything from same origin)

## Test plan
- [ ] `make dev` — open `http://localhost:3000/console/`, verify no "Load failed" errors
- [ ] API calls from dashboard work (list workspaces, create session, etc.)