### PR TITLE
feat: workspace rename (#50) and session history (#51)

### DIFF
--- a/cmd/zynqel-core/main.go
+++ b/cmd/zynqel-core/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/Rsych/zynqel-core/internal/sandbox"
 	"github.com/Rsych/zynqel-core/internal/server"
 	"github.com/Rsych/zynqel-core/internal/session"
+	"github.com/Rsych/zynqel-core/internal/sessionlog"
 )
 
 func main() {
@@ -64,7 +67,25 @@ func main() {
 		log.Printf("warning: failed to load agent configs: %v", err)
 	}
 
-	sm := session.NewManager(sb, rp, agentStore)
+	// Create session log store for persisting session history.
+	logPTY := strings.EqualFold(os.Getenv("ZYNQEL_LOG_PTY"), "true")
+	retentionDays := 30
+	if v := os.Getenv("ZYNQEL_LOG_RETENTION_DAYS"); v != "" {
+		if d, err := strconv.Atoi(v); err == nil && d > 0 {
+			retentionDays = d
+		}
+	}
+	logStore, err := sessionlog.NewStore(dataDir, logPTY, retentionDays)
+	if err != nil {
+		log.Fatalf("failed to create session log store: %v", err)
+	}
+	if removed, err := logStore.Cleanup(); err != nil {
+		log.Printf("warning: session log cleanup: %v", err)
+	} else if removed > 0 {
+		log.Printf("session log cleanup: removed %d old record(s)", removed)
+	}
+
+	sm := session.NewManager(sb, rp, agentStore, logStore)
 
 	// Serve dashboard from web/out/ (Next.js static export).
 	var webFS fs.FS
@@ -72,7 +93,7 @@ func main() {
 		webFS = os.DirFS("web/out")
 		log.Println("serving dashboard from web/out/")
 	}
-	srv := server.New(sm, agentStore, sb, webFS)
+	srv := server.New(sm, agentStore, sb, logStore, webFS)
 
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf(":%s", port),

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -379,6 +379,79 @@ func (d *DockerSandbox) RemoveVolume(ctx context.Context, name string) error {
 	return d.cli.VolumeRemove(ctx, name, true)
 }
 
+// CopyVolume copies all data from one Docker volume to a new volume.
+// Docker doesn't support native volume rename, so we create a new volume,
+// run a temporary container to copy data, then the caller removes the old volume.
+func (d *DockerSandbox) CopyVolume(ctx context.Context, srcName, dstName string) error {
+	// Create the destination volume.
+	if _, err := d.cli.VolumeCreate(ctx, volume.CreateOptions{Name: dstName}); err != nil {
+		return fmt.Errorf("create volume %s: %w", dstName, err)
+	}
+
+	// Run a temporary container to copy data between volumes.
+	config := &container.Config{
+		Image: "alpine:latest",
+		Cmd:   []string{"cp", "-a", "/src/.", "/dst/"},
+	}
+	hostConfig := &container.HostConfig{
+		Mounts: []mount.Mount{
+			{Type: mount.TypeVolume, Source: srcName, Target: "/src", ReadOnly: true},
+			{Type: mount.TypeVolume, Source: dstName, Target: "/dst"},
+		},
+	}
+
+	if err := d.ensureImage(ctx, "alpine:latest"); err != nil {
+		_ = d.cli.VolumeRemove(ctx, dstName, true)
+		return fmt.Errorf("ensure alpine image: %w", err)
+	}
+
+	resp, err := d.cli.ContainerCreate(ctx, config, hostConfig, nil, nil, "")
+	if err != nil {
+		_ = d.cli.VolumeRemove(ctx, dstName, true)
+		return fmt.Errorf("create copy container: %w", err)
+	}
+	defer func() { _ = d.cli.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true}) }()
+
+	if err := d.cli.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+		_ = d.cli.VolumeRemove(ctx, dstName, true)
+		return fmt.Errorf("start copy container: %w", err)
+	}
+
+	statusCh, errCh := d.cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			_ = d.cli.VolumeRemove(ctx, dstName, true)
+			return fmt.Errorf("wait copy container: %w", err)
+		}
+	case status := <-statusCh:
+		if status.StatusCode != 0 {
+			_ = d.cli.VolumeRemove(ctx, dstName, true)
+			return fmt.Errorf("copy container exited with code %d", status.StatusCode)
+		}
+	}
+
+	log.Printf("copied volume %s → %s", srcName, dstName)
+	return nil
+}
+
+// TagImage tags a Docker image with a new name.
+func (d *DockerSandbox) TagImage(ctx context.Context, oldName, newName string) error {
+	if err := d.cli.ImageTag(ctx, oldName, newName); err != nil {
+		return fmt.Errorf("tag image %s → %s: %w", oldName, newName, err)
+	}
+	return nil
+}
+
+// RemoveImage removes a Docker image by name.
+func (d *DockerSandbox) RemoveImage(ctx context.Context, imageName string) error {
+	_, err := d.cli.ImageRemove(ctx, imageName, image.RemoveOptions{})
+	if err != nil {
+		return fmt.Errorf("remove image %s: %w", imageName, err)
+	}
+	return nil
+}
+
 // Resize changes the TTY dimensions of a running container.
 func (d *DockerSandbox) Resize(ctx context.Context, id string, cols, rows int) error {
 	if cols <= 0 || rows <= 0 {

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -28,6 +28,9 @@ type Sandbox interface {
 	BuildImage(ctx context.Context, dockerfile, imageName string) error
 	ListVolumes(ctx context.Context, prefix string) ([]VolumeInfo, error)
 	RemoveVolume(ctx context.Context, name string) error
+	CopyVolume(ctx context.Context, srcName, dstName string) error
+	TagImage(ctx context.Context, oldName, newName string) error
+	RemoveImage(ctx context.Context, imageName string) error
 }
 
 // ContainerStats holds point-in-time resource usage for a container.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Rsych/zynqel-core/internal/agentcfg"
 	"github.com/Rsych/zynqel-core/internal/sandbox"
 	"github.com/Rsych/zynqel-core/internal/session"
+	"github.com/Rsych/zynqel-core/internal/sessionlog"
 )
 
 type Server struct {
@@ -15,16 +16,18 @@ type Server struct {
 	sessions *session.Manager
 	agents   *agentcfg.Store
 	sandbox  sandbox.Sandbox
+	logStore *sessionlog.Store
 }
 
-// New takes a session.Manager, agent config store, sandbox, and a filesystem for static web assets.
+// New takes a session.Manager, agent config store, sandbox, log store, and a filesystem for static web assets.
 // Pass nil for webFS to disable the dashboard.
-func New(sm *session.Manager, agents *agentcfg.Store, sb sandbox.Sandbox, webFS fs.FS) *Server {
+func New(sm *session.Manager, agents *agentcfg.Store, sb sandbox.Sandbox, logStore *sessionlog.Store, webFS fs.FS) *Server {
 	s := &Server{
 		router:   http.NewServeMux(),
 		sessions: sm,
 		agents:   agents,
 		sandbox:  sb,
+		logStore: logStore,
 	}
 	s.routes(webFS)
 	return s
@@ -45,7 +48,12 @@ func (s *Server) routes(webFS fs.FS) {
 	s.router.HandleFunc("PUT /agents/{name}", s.handleUpdateAgent)
 	s.router.HandleFunc("DELETE /agents/{name}", s.handleDeleteAgent)
 	s.router.HandleFunc("GET /system/info", s.handleSystemInfo)
+	s.router.HandleFunc("GET /sessions/history", s.handleListSessionHistory)
+	s.router.HandleFunc("GET /sessions/history/{id}", s.handleGetSessionHistory)
+	s.router.HandleFunc("GET /sessions/history/{id}/log", s.handleGetSessionLog)
+	s.router.HandleFunc("DELETE /sessions/history/{id}", s.handleDeleteSessionHistory)
 	s.router.HandleFunc("GET /workspaces", s.handleListWorkspaces)
+	s.router.HandleFunc("PUT /workspaces/{id}", s.handleRenameWorkspace)
 	s.router.HandleFunc("DELETE /workspaces/{id}", s.handleDeleteWorkspace)
 
 	if webFS != nil {

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Rsych/zynqel-core/internal/session"
+	"github.com/Rsych/zynqel-core/internal/sessionlog"
 )
 
 // handleCreateSession decodes a SessionSpec from the request body
@@ -126,6 +129,38 @@ func (s *Server) handleDeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// handleRenameWorkspace renames a workspace volume and committed image.
+func (s *Server) handleRenameWorkspace(w http.ResponseWriter, r *http.Request) {
+	oldID := r.PathValue("id")
+	var body struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if body.ID == "" {
+		writeError(w, http.StatusBadRequest, "id is required")
+		return
+	}
+
+	if err := s.sessions.RenameWorkspace(r.Context(), oldID, body.ID); err != nil {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "active session"), strings.Contains(msg, "already exists"):
+			writeError(w, http.StatusConflict, msg)
+		case strings.Contains(msg, "invalid workspace_id"):
+			writeError(w, http.StatusBadRequest, msg)
+		default:
+			log.Printf("error renaming workspace %s → %s: %v", oldID, body.ID, err)
+			writeError(w, http.StatusInternalServerError, "failed to rename workspace")
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"id": body.ID})
+}
+
 // handleSessionStats returns container CPU/memory stats.
 func (s *Server) handleSessionStats(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
@@ -150,6 +185,82 @@ func (s *Server) handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 		"idle_timeout": p.IdleTimeoutSec,
 		"hard_timeout": p.HardTimeoutSec,
 	})
+}
+
+// handleListSessionHistory returns past session records.
+func (s *Server) handleListSessionHistory(w http.ResponseWriter, r *http.Request) {
+	if s.logStore == nil {
+		writeJSON(w, http.StatusOK, []struct{}{})
+		return
+	}
+	records, err := s.logStore.List()
+	if err != nil {
+		log.Printf("error listing session history: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to list session history")
+		return
+	}
+
+	// Filter by workspace_id if provided.
+	if wsID := r.URL.Query().Get("workspace_id"); wsID != "" {
+		var filtered []sessionlog.Record
+		for _, rec := range records {
+			if rec.WorkspaceID == wsID {
+				filtered = append(filtered, rec)
+			}
+		}
+		records = filtered
+	}
+
+	writeJSON(w, http.StatusOK, records)
+}
+
+// handleGetSessionHistory returns a single session record.
+func (s *Server) handleGetSessionHistory(w http.ResponseWriter, r *http.Request) {
+	if s.logStore == nil {
+		writeError(w, http.StatusNotFound, "session history not found")
+		return
+	}
+	id := r.PathValue("id")
+	rec, err := s.logStore.Get(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "session history not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, rec)
+}
+
+// handleGetSessionLog streams a session's PTY log as plain text.
+func (s *Server) handleGetSessionLog(w http.ResponseWriter, r *http.Request) {
+	if s.logStore == nil {
+		writeError(w, http.StatusNotFound, "no log available")
+		return
+	}
+	id := r.PathValue("id")
+	rc, err := s.logStore.ReadLog(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "no log available")
+		return
+	}
+	defer func() { _ = rc.Close() }()
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	if _, err := io.Copy(w, rc); err != nil {
+		log.Printf("error streaming session log %s: %v", id, err)
+	}
+}
+
+// handleDeleteSessionHistory removes a session record and its log.
+func (s *Server) handleDeleteSessionHistory(w http.ResponseWriter, r *http.Request) {
+	if s.logStore == nil {
+		writeError(w, http.StatusNotFound, "session history not found")
+		return
+	}
+	id := r.PathValue("id")
+	if err := s.logStore.Delete(id); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete session history")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // writeJSON is a helper to send JSON responses.

--- a/internal/session/broadcaster.go
+++ b/internal/session/broadcaster.go
@@ -37,8 +37,9 @@ type Broadcaster struct {
 	conn        sandbox.PTYConn
 	ring        *pty.RingBuffer
 	intercepter *intercept.Intercepter
-	onActivity  func() // called on PTY read/write activity
-	onExit      func() // called when PTY read loop ends (agent exited)
+	onActivity  func()         // called on PTY read/write activity
+	onExit      func()         // called when PTY read loop ends (agent exited)
+	logWriter   io.WriteCloser // optional: writes PTY output to a log file
 	mu          sync.Mutex
 	subs        map[*Subscriber]struct{}
 	stopped     chan struct{}
@@ -48,13 +49,15 @@ type Broadcaster struct {
 // NewBroadcaster creates a Broadcaster and starts reading from conn.
 // bufSize is the ring buffer size in bytes (0 = default 64KB).
 // onActivity is called on every PTY read/write (for idle tracking). May be nil.
-func NewBroadcaster(conn sandbox.PTYConn, bufSize int, onActivity func(), onExit func()) *Broadcaster {
+// logWriter, if non-nil, receives a copy of all PTY output for persistent logging.
+func NewBroadcaster(conn sandbox.PTYConn, bufSize int, onActivity func(), onExit func(), logWriter io.WriteCloser) *Broadcaster {
 	b := &Broadcaster{
 		conn:        conn,
 		ring:        pty.NewRingBuffer(bufSize),
 		intercepter: intercept.New(),
 		onActivity:  onActivity,
 		onExit:      onExit,
+		logWriter:   logWriter,
 		subs:        make(map[*Subscriber]struct{}),
 		stopped:     make(chan struct{}),
 	}
@@ -117,6 +120,9 @@ func (b *Broadcaster) readLoop() {
 	defer close(b.stopped)
 	defer b.closeAllSubscribers()
 	defer func() {
+		if b.logWriter != nil {
+			_ = b.logWriter.Close()
+		}
 		if b.onExit != nil {
 			b.onExit()
 		}
@@ -132,6 +138,13 @@ func (b *Broadcaster) readLoop() {
 
 			chunk := make([]byte, n)
 			copy(chunk, buf[:n])
+
+			// Write to persistent log if enabled.
+			if b.logWriter != nil {
+				if _, werr := b.logWriter.Write(chunk); werr != nil {
+					log.Printf("warning: PTY log write error: %v", werr)
+				}
+			}
 
 			// Scan for prompts before fan-out.
 			prompts := b.intercepter.Scan(chunk)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -507,11 +507,20 @@ func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) erro
 
 	// Hold write lock for check + creating guard to prevent TOCTOU race:
 	// no new session can start on oldID while the rename is in progress.
+	// Create() checks m.creating[spec.WorkspaceID] before proceeding,
+	// so setting m.creating[oldID] blocks concurrent session creation.
 	m.mu.Lock()
+	var stoppingSessions []*Session
 	for _, s := range m.sessions {
-		if s.Spec.WorkspaceID == oldID && s.Status == StatusRunning {
+		if s.Spec.WorkspaceID != oldID {
+			continue
+		}
+		if s.Status == StatusRunning {
 			m.mu.Unlock()
 			return fmt.Errorf("cannot rename workspace with active session")
+		}
+		if s.Status == StatusStopped {
+			stoppingSessions = append(stoppingSessions, s)
 		}
 	}
 	if _, ok := m.creating[oldID]; ok {
@@ -526,6 +535,12 @@ func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) erro
 		delete(m.creating, oldID)
 		m.mu.Unlock()
 	}()
+
+	// Wait for any mid-stop sessions to finish cleanup (commit + container stop)
+	// before copying the volume, to avoid racing with the container commit.
+	for _, s := range stoppingSessions {
+		waitStopDone(s)
+	}
 
 	// Check target volume doesn't already exist.
 	oldVolume := volumePrefix + oldID

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -253,7 +253,8 @@ func (m *Manager) Create(ctx context.Context, spec SessionSpec) (*Session, error
 		}
 	}
 	defer func() {
-		// If we return before NewBroadcaster takes ownership, close the writer.
+		// Safety net: if we return before NewBroadcaster takes ownership, close the writer.
+		// The logWriter = nil after NewBroadcaster (below) is critical to prevent double-close.
 		if logWriter != nil {
 			_ = logWriter.Close()
 		}
@@ -562,11 +563,20 @@ func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) erro
 	}
 
 	// Copy volume data.
+	// Crash recovery: if the process crashes after CopyVolume but before
+	// RemoveVolume, both volumes will exist. Recovery is manual:
+	//   docker volume rm zynqel-ws-<newID>   (if rename should be retried)
+	//   docker volume rm zynqel-ws-<oldID>   (if rename should be completed)
+	// A future reconciliation pass could detect duplicate volumes by checking
+	// for pairs where one is a prefix-match of a recent rename log entry.
 	if err := m.sandbox.CopyVolume(ctx, oldVolume, newVolume); err != nil {
 		return fmt.Errorf("copy volume: %w", err)
 	}
 
 	// Rename committed image if it exists.
+	// Note: if old image removal fails, the stale tag persists. A subsequent
+	// rename back to the old ID could find this stale image — operators should
+	// run `docker image prune` periodically to clean up dangling tags.
 	oldImage := oldVolume + ":latest"
 	newImage := newVolume + ":latest"
 	if m.sandbox.ImageExists(ctx, oldImage) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -527,12 +527,18 @@ func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) erro
 		m.mu.Unlock()
 		return fmt.Errorf("workspace %s is currently being created", oldID)
 	}
+	if _, ok := m.creating[newID]; ok {
+		m.mu.Unlock()
+		return fmt.Errorf("workspace %s is currently being created", newID)
+	}
 	m.creating[oldID] = struct{}{}
+	m.creating[newID] = struct{}{}
 	m.mu.Unlock()
 
 	defer func() {
 		m.mu.Lock()
 		delete(m.creating, oldID)
+		delete(m.creating, newID)
 		m.mu.Unlock()
 	}()
 
@@ -568,6 +574,7 @@ func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) erro
 			// Rollback: remove the new volume.
 			if rmErr := m.sandbox.RemoveVolume(ctx, newVolume); rmErr != nil {
 				log.Printf("ERROR: rollback failed, orphaned volume %s must be removed manually: %v", newVolume, rmErr)
+				return fmt.Errorf("tag image: %w (rollback failed, orphaned volume %s)", err, newVolume)
 			}
 			return fmt.Errorf("tag image: %w", err)
 		}
@@ -820,10 +827,14 @@ func (m *Manager) setupGitCredentials(ctx context.Context, containerID string, s
 }
 
 // saveSessionRecord persists session metadata to the log store.
+// Reads session fields under m.mu to prevent data races with concurrent mutations.
 func (m *Manager) saveSessionRecord(s *Session) {
 	if m.logStore == nil {
 		return
 	}
+
+	// Snapshot mutable fields under lock.
+	m.mu.RLock()
 	r := sessionlog.Record{
 		ID:          s.ID,
 		WorkspaceID: s.Spec.WorkspaceID,
@@ -833,15 +844,15 @@ func (m *Manager) saveSessionRecord(s *Session) {
 		Branch:      s.Spec.Branch,
 		Status:      string(s.Status),
 		CreatedAt:   s.CreatedAt,
+		Error:       s.Error,
 	}
 	if s.StoppedAt != nil {
 		r.StoppedAt = *s.StoppedAt
 	} else {
 		r.StoppedAt = time.Now()
 	}
-	if s.Error != "" {
-		r.Error = s.Error
-	}
+	m.mu.RUnlock()
+
 	if err := m.logStore.Save(r); err != nil {
 		log.Printf("warning: failed to save session record %s: %v", s.ID, err)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -562,6 +562,10 @@ func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) erro
 		}
 	}
 
+	// Log intent before starting multi-step operation so a future reconciliation
+	// tool can detect orphaned volumes from incomplete renames.
+	log.Printf("rename workspace: starting %s → %s (volume %s → %s)", oldID, newID, oldVolume, newVolume)
+
 	// Copy volume data.
 	// Crash recovery: if the process crashes after CopyVolume but before
 	// RemoveVolume, both volumes will exist. Recovery is manual:

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -311,6 +311,8 @@ func (m *Manager) Stop(_ context.Context, id string) error {
 	s.stopDone = make(chan struct{})
 
 	// Heavy cleanup in background — commit, then stop container.
+	// Note: broadcaster.Close() triggers readLoop exit, which closes the PTY logWriter
+	// via its defer chain (see readLoop in broadcaster.go).
 	go func() {
 		defer close(s.stopDone)
 		if !atomic.CompareAndSwapInt32(&s.cleaned, 0, 1) {
@@ -379,9 +381,11 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 	waitStopDone(s)
 
 	if s.Status == StatusStopped {
+		// Stop goroutine already saved the session record.
 		_ = m.sandbox.Remove(ctx, s.ContainerID)
 	} else {
 		m.cleanupSession(ctx, s)
+		m.saveSessionRecord(s)
 	}
 	return nil
 }
@@ -607,9 +611,11 @@ func (m *Manager) Shutdown(ctx context.Context) {
 	for _, s := range sessions {
 		waitStopDone(s)
 		if s.Status == StatusStopped {
+			// Stop goroutine already saved the session record.
 			_ = m.sandbox.Remove(ctx, s.ContainerID)
 		} else {
 			m.cleanupSession(ctx, s)
+			m.saveSessionRecord(s)
 		}
 		log.Printf("cleaned up session %s", s.ID)
 	}
@@ -617,6 +623,9 @@ func (m *Manager) Shutdown(ctx context.Context) {
 
 // cleanupSession stops the broadcaster and container.
 // Safe to call multiple times — guarded by atomic flag.
+// Does NOT save a session history record; callers that need persistence
+// should call saveSessionRecord separately (early-error cleanup during Create
+// passes incomplete sessions that shouldn't be recorded).
 func (m *Manager) cleanupSession(ctx context.Context, s *Session) {
 	if !atomic.CompareAndSwapInt32(&s.cleaned, 0, 1) {
 		_ = m.sandbox.Remove(ctx, s.ContainerID)
@@ -638,7 +647,6 @@ func (m *Manager) cleanupSession(ctx context.Context, s *Session) {
 	if err := m.sandbox.Remove(ctx, s.ContainerID); err != nil {
 		log.Printf("warning: failed to remove container %s: %v", shortid.Format(s.ContainerID), err)
 	}
-	m.saveSessionRecord(s)
 }
 
 // StartTimeoutChecker runs a background goroutine that terminates idle

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -482,6 +482,7 @@ func (m *Manager) DeleteWorkspace(ctx context.Context, wsID string) error {
 
 // RenameWorkspace renames a workspace by copying its volume and committed image.
 // Returns an error if the workspace has a running session or the new ID already exists.
+// Uses the creating guard to prevent new sessions from starting on the workspace during rename.
 func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) error {
 	newID = strings.ToLower(newID)
 	if !validWorkspaceID.MatchString(newID) {
@@ -491,15 +492,27 @@ func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) erro
 		return nil
 	}
 
-	// Check for running sessions and existing target under lock.
-	m.mu.RLock()
+	// Hold write lock for check + creating guard to prevent TOCTOU race:
+	// no new session can start on oldID while the rename is in progress.
+	m.mu.Lock()
 	for _, s := range m.sessions {
 		if s.Spec.WorkspaceID == oldID && s.Status == StatusRunning {
-			m.mu.RUnlock()
+			m.mu.Unlock()
 			return fmt.Errorf("cannot rename workspace with active session")
 		}
 	}
-	m.mu.RUnlock()
+	if _, ok := m.creating[oldID]; ok {
+		m.mu.Unlock()
+		return fmt.Errorf("workspace %s is currently being created", oldID)
+	}
+	m.creating[oldID] = struct{}{}
+	m.mu.Unlock()
+
+	defer func() {
+		m.mu.Lock()
+		delete(m.creating, oldID)
+		m.mu.Unlock()
+	}()
 
 	// Check target volume doesn't already exist.
 	oldVolume := volumePrefix + oldID
@@ -528,8 +541,9 @@ func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) erro
 			_ = m.sandbox.RemoveVolume(ctx, newVolume)
 			return fmt.Errorf("tag image: %w", err)
 		}
+		// Best-effort removal of old tag; new tag already exists.
 		if err := m.sandbox.RemoveImage(ctx, oldImage); err != nil {
-			log.Printf("warning: failed to remove old image %s: %v", oldImage, err)
+			log.Printf("warning: failed to remove old image tag %s (new tag exists): %v", oldImage, err)
 		}
 	}
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -241,6 +241,8 @@ func (m *Manager) Create(ctx context.Context, spec SessionSpec) (*Session, error
 	}
 
 	// Open PTY log writer if session logging is enabled.
+	// Ownership transfers to the broadcaster's readLoop, which closes it on exit.
+	// Guard against leaks if anything fails before NewBroadcaster.
 	var logWriter io.WriteCloser
 	if m.logStore != nil && m.logStore.LogPTY() {
 		w, err := m.logStore.OpenLogWriter(id)
@@ -250,6 +252,12 @@ func (m *Manager) Create(ctx context.Context, spec SessionSpec) (*Session, error
 			logWriter = w
 		}
 	}
+	defer func() {
+		// If we return before NewBroadcaster takes ownership, close the writer.
+		if logWriter != nil {
+			_ = logWriter.Close()
+		}
+	}()
 
 	s := &Session{
 		ID:          id,
@@ -260,6 +268,7 @@ func (m *Manager) Create(ctx context.Context, spec SessionSpec) (*Session, error
 	}
 	s.TouchActivity()
 	s.broadcaster = NewBroadcaster(broadcastConn, DefaultBufferSize, s.TouchActivity, nil, logWriter)
+	logWriter = nil // ownership transferred to broadcaster
 
 	m.mu.Lock()
 	m.sessions[id] = s
@@ -542,7 +551,9 @@ func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) erro
 	if m.sandbox.ImageExists(ctx, oldImage) {
 		if err := m.sandbox.TagImage(ctx, oldImage, newImage); err != nil {
 			// Rollback: remove the new volume.
-			_ = m.sandbox.RemoveVolume(ctx, newVolume)
+			if rmErr := m.sandbox.RemoveVolume(ctx, newVolume); rmErr != nil {
+				log.Printf("ERROR: rollback failed, orphaned volume %s must be removed manually: %v", newVolume, rmErr)
+			}
 			return fmt.Errorf("tag image: %w", err)
 		}
 		// Best-effort removal of old tag; new tag already exists.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"regexp"
@@ -18,6 +19,7 @@ import (
 	"github.com/Rsych/zynqel-core/internal/agentcfg"
 	"github.com/Rsych/zynqel-core/internal/policy"
 	"github.com/Rsych/zynqel-core/internal/sandbox"
+	"github.com/Rsych/zynqel-core/internal/sessionlog"
 	"github.com/Rsych/zynqel-core/internal/shortid"
 )
 
@@ -54,17 +56,19 @@ type Manager struct {
 	sandbox     sandbox.Sandbox
 	policy      policy.ResourcePolicy
 	agents      *agentcfg.Store
+	logStore    *sessionlog.Store
 	idleTimeout time.Duration
 	hardTimeout time.Duration
 }
 
-func NewManager(sb sandbox.Sandbox, p policy.ResourcePolicy, agents *agentcfg.Store) *Manager {
+func NewManager(sb sandbox.Sandbox, p policy.ResourcePolicy, agents *agentcfg.Store, logStore *sessionlog.Store) *Manager {
 	return &Manager{
 		sessions:    make(map[string]*Session),
 		creating:    make(map[string]struct{}),
 		sandbox:     sb,
 		policy:      p,
 		agents:      agents,
+		logStore:    logStore,
 		idleTimeout: time.Duration(p.IdleTimeoutSec) * time.Second,
 		hardTimeout: time.Duration(p.HardTimeoutSec) * time.Second,
 	}
@@ -236,6 +240,17 @@ func (m *Manager) Create(ctx context.Context, spec SessionSpec) (*Session, error
 		return nil, fmt.Errorf("attach for broadcast: %w", err)
 	}
 
+	// Open PTY log writer if session logging is enabled.
+	var logWriter io.WriteCloser
+	if m.logStore != nil && m.logStore.LogPTY() {
+		w, err := m.logStore.OpenLogWriter(id)
+		if err != nil {
+			log.Printf("warning: failed to open PTY log for session %s: %v", id, err)
+		} else {
+			logWriter = w
+		}
+	}
+
 	s := &Session{
 		ID:          id,
 		Spec:        spec,
@@ -244,7 +259,7 @@ func (m *Manager) Create(ctx context.Context, spec SessionSpec) (*Session, error
 		CreatedAt:   time.Now(),
 	}
 	s.TouchActivity()
-	s.broadcaster = NewBroadcaster(broadcastConn, DefaultBufferSize, s.TouchActivity, nil)
+	s.broadcaster = NewBroadcaster(broadcastConn, DefaultBufferSize, s.TouchActivity, nil, logWriter)
 
 	m.mu.Lock()
 	m.sessions[id] = s
@@ -316,6 +331,7 @@ func (m *Manager) Stop(_ context.Context, id string) error {
 		if err := m.sandbox.Stop(ctx, s.ContainerID); err != nil {
 			log.Printf("warning: failed to stop container %s: %v", shortid.Format(s.ContainerID), err)
 		}
+		m.saveSessionRecord(s)
 		log.Printf("session %s stopped", s.ID)
 	}()
 
@@ -464,6 +480,77 @@ func (m *Manager) DeleteWorkspace(ctx context.Context, wsID string) error {
 	return m.sandbox.RemoveVolume(ctx, volumePrefix+wsID)
 }
 
+// RenameWorkspace renames a workspace by copying its volume and committed image.
+// Returns an error if the workspace has a running session or the new ID already exists.
+func (m *Manager) RenameWorkspace(ctx context.Context, oldID, newID string) error {
+	newID = strings.ToLower(newID)
+	if !validWorkspaceID.MatchString(newID) {
+		return fmt.Errorf("invalid workspace_id %q: must be lowercase alphanumeric, hyphens, underscores", newID)
+	}
+	if oldID == newID {
+		return nil
+	}
+
+	// Check for running sessions and existing target under lock.
+	m.mu.RLock()
+	for _, s := range m.sessions {
+		if s.Spec.WorkspaceID == oldID && s.Status == StatusRunning {
+			m.mu.RUnlock()
+			return fmt.Errorf("cannot rename workspace with active session")
+		}
+	}
+	m.mu.RUnlock()
+
+	// Check target volume doesn't already exist.
+	oldVolume := volumePrefix + oldID
+	newVolume := volumePrefix + newID
+	vols, err := m.sandbox.ListVolumes(ctx, newVolume)
+	if err != nil {
+		return fmt.Errorf("check target volume: %w", err)
+	}
+	for _, v := range vols {
+		if v.Name == newVolume {
+			return fmt.Errorf("workspace %q already exists", newID)
+		}
+	}
+
+	// Copy volume data.
+	if err := m.sandbox.CopyVolume(ctx, oldVolume, newVolume); err != nil {
+		return fmt.Errorf("copy volume: %w", err)
+	}
+
+	// Rename committed image if it exists.
+	oldImage := oldVolume + ":latest"
+	newImage := newVolume + ":latest"
+	if m.sandbox.ImageExists(ctx, oldImage) {
+		if err := m.sandbox.TagImage(ctx, oldImage, newImage); err != nil {
+			// Rollback: remove the new volume.
+			_ = m.sandbox.RemoveVolume(ctx, newVolume)
+			return fmt.Errorf("tag image: %w", err)
+		}
+		if err := m.sandbox.RemoveImage(ctx, oldImage); err != nil {
+			log.Printf("warning: failed to remove old image %s: %v", oldImage, err)
+		}
+	}
+
+	// Remove old volume.
+	if err := m.sandbox.RemoveVolume(ctx, oldVolume); err != nil {
+		log.Printf("warning: failed to remove old volume %s: %v", oldVolume, err)
+	}
+
+	// Update any stopped sessions referencing the old workspace ID.
+	m.mu.Lock()
+	for _, s := range m.sessions {
+		if s.Spec.WorkspaceID == oldID {
+			s.Spec.WorkspaceID = newID
+		}
+	}
+	m.mu.Unlock()
+
+	log.Printf("renamed workspace %s → %s", oldID, newID)
+	return nil
+}
+
 // Stats returns container resource usage for a session.
 func (m *Manager) Stats(ctx context.Context, id string) (*sandbox.ContainerStats, error) {
 	m.mu.RLock()
@@ -537,6 +624,7 @@ func (m *Manager) cleanupSession(ctx context.Context, s *Session) {
 	if err := m.sandbox.Remove(ctx, s.ContainerID); err != nil {
 		log.Printf("warning: failed to remove container %s: %v", shortid.Format(s.ContainerID), err)
 	}
+	m.saveSessionRecord(s)
 }
 
 // StartTimeoutChecker runs a background goroutine that terminates idle
@@ -681,6 +769,34 @@ func (m *Manager) setupGitCredentials(ctx context.Context, containerID string, s
 	}
 
 	return nil
+}
+
+// saveSessionRecord persists session metadata to the log store.
+func (m *Manager) saveSessionRecord(s *Session) {
+	if m.logStore == nil {
+		return
+	}
+	r := sessionlog.Record{
+		ID:          s.ID,
+		WorkspaceID: s.Spec.WorkspaceID,
+		Agent:       s.Spec.Agent,
+		Image:       s.Spec.Image,
+		RepoURL:     s.Spec.RepoURL,
+		Branch:      s.Spec.Branch,
+		Status:      string(s.Status),
+		CreatedAt:   s.CreatedAt,
+	}
+	if s.StoppedAt != nil {
+		r.StoppedAt = *s.StoppedAt
+	} else {
+		r.StoppedAt = time.Now()
+	}
+	if s.Error != "" {
+		r.Error = s.Error
+	}
+	if err := m.logStore.Save(r); err != nil {
+		log.Printf("warning: failed to save session record %s: %v", s.ID, err)
+	}
 }
 
 func generateID() (string, error) {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -47,7 +47,7 @@ func mustManager(t *testing.T, sb sandbox.Sandbox) *Manager {
 	t.Helper()
 	p := policy.DefaultPolicy()
 	p.MaxSessions = 100 // allow more for stability tests
-	return NewManager(sb, p, nil)
+	return NewManager(sb, p, nil, nil)
 }
 
 func goroutineCount() int {

--- a/internal/session/mock_sandbox_test.go
+++ b/internal/session/mock_sandbox_test.go
@@ -60,6 +60,12 @@ func (m *mockSandbox) ListVolumes(_ context.Context, _ string) ([]sandbox.Volume
 
 func (m *mockSandbox) RemoveVolume(_ context.Context, _ string) error { return nil }
 
+func (m *mockSandbox) CopyVolume(_ context.Context, _, _ string) error { return nil }
+
+func (m *mockSandbox) TagImage(_ context.Context, _, _ string) error { return nil }
+
+func (m *mockSandbox) RemoveImage(_ context.Context, _ string) error { return nil }
+
 // pipePTYConn adapts io.Pipe into a sandbox.PTYConn.
 // Closing the reader unblocks the broadcaster's readLoop.
 type pipePTYConn struct {

--- a/internal/sessionlog/store.go
+++ b/internal/sessionlog/store.go
@@ -1,0 +1,184 @@
+package sessionlog
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Record represents a completed session's metadata persisted to disk.
+type Record struct {
+	ID          string    `json:"id"`
+	WorkspaceID string    `json:"workspace_id,omitempty"`
+	Agent       string    `json:"agent"`
+	Image       string    `json:"image,omitempty"`
+	RepoURL     string    `json:"repo_url,omitempty"`
+	Branch      string    `json:"branch,omitempty"`
+	Status      string    `json:"status"`
+	CreatedAt   time.Time `json:"created_at"`
+	StoppedAt   time.Time `json:"stopped_at,omitempty"`
+	Duration    string    `json:"duration,omitempty"`
+	Error       string    `json:"error,omitempty"`
+	HasLog      bool      `json:"has_log"`
+}
+
+// Store persists session records and optional PTY logs to disk.
+type Store struct {
+	dir           string // $ZYNQEL_DATA_DIR/sessions
+	logDir        string // $ZYNQEL_DATA_DIR/logs
+	logPTY        bool
+	retentionDays int
+}
+
+// NewStore creates a Store. Directories are created if they don't exist.
+func NewStore(dataDir string, logPTY bool, retentionDays int) (*Store, error) {
+	dir := filepath.Join(dataDir, "sessions")
+	logDir := filepath.Join(dataDir, "logs")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create sessions dir: %w", err)
+	}
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create logs dir: %w", err)
+	}
+	if retentionDays <= 0 {
+		retentionDays = 30
+	}
+	return &Store{
+		dir:           dir,
+		logDir:        logDir,
+		logPTY:        logPTY,
+		retentionDays: retentionDays,
+	}, nil
+}
+
+// LogPTY returns whether PTY logging is enabled.
+func (s *Store) LogPTY() bool { return s.logPTY }
+
+// Save writes a session record to disk.
+func (s *Store) Save(r Record) error {
+	// Compute duration if we have both timestamps.
+	if !r.StoppedAt.IsZero() && !r.CreatedAt.IsZero() {
+		r.Duration = r.StoppedAt.Sub(r.CreatedAt).Truncate(time.Second).String()
+	}
+
+	// Check if a PTY log exists for this session.
+	if _, err := os.Stat(filepath.Join(s.logDir, r.ID+".log")); err == nil {
+		r.HasLog = true
+	}
+
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal session record: %w", err)
+	}
+	path := filepath.Join(s.dir, r.ID+".json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write session record: %w", err)
+	}
+	return nil
+}
+
+// List returns all session records sorted by created_at descending.
+func (s *Store) List() ([]Record, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, fmt.Errorf("read sessions dir: %w", err)
+	}
+	var records []Record
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		r, err := s.readRecord(filepath.Join(s.dir, e.Name()))
+		if err != nil {
+			log.Printf("warning: skip bad session record %s: %v", e.Name(), err)
+			continue
+		}
+		records = append(records, r)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].CreatedAt.After(records[j].CreatedAt)
+	})
+	return records, nil
+}
+
+// Get returns a single session record by ID.
+func (s *Store) Get(id string) (*Record, error) {
+	path := filepath.Join(s.dir, id+".json")
+	r, err := s.readRecord(path)
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// Delete removes a session record and its log file.
+func (s *Store) Delete(id string) error {
+	_ = os.Remove(filepath.Join(s.dir, id+".json"))
+	_ = os.Remove(filepath.Join(s.logDir, id+".log"))
+	return nil
+}
+
+// OpenLogWriter opens a log file for writing PTY output.
+// The caller is responsible for closing the writer.
+func (s *Store) OpenLogWriter(id string) (io.WriteCloser, error) {
+	path := filepath.Join(s.logDir, id+".log")
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create log file: %w", err)
+	}
+	return f, nil
+}
+
+// ReadLog opens a session's PTY log file for reading.
+// Returns os.ErrNotExist if no log exists.
+func (s *Store) ReadLog(id string) (io.ReadCloser, error) {
+	path := filepath.Join(s.logDir, id+".log")
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// Cleanup removes records older than the retention period. Returns count removed.
+func (s *Store) Cleanup() (int, error) {
+	cutoff := time.Now().AddDate(0, 0, -s.retentionDays)
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return 0, fmt.Errorf("read sessions dir: %w", err)
+	}
+	removed := 0
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		r, err := s.readRecord(filepath.Join(s.dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		if r.CreatedAt.Before(cutoff) {
+			id := strings.TrimSuffix(e.Name(), ".json")
+			_ = s.Delete(id)
+			removed++
+		}
+	}
+	return removed, nil
+}
+
+func (s *Store) readRecord(path string) (Record, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Record{}, err
+	}
+	var r Record
+	if err := json.Unmarshal(data, &r); err != nil {
+		return Record{}, err
+	}
+	return r, nil
+}

--- a/internal/sessionlog/store.go
+++ b/internal/sessionlog/store.go
@@ -7,10 +7,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
 )
+
+// validID matches safe session IDs (hex strings or alphanumeric with hyphens/underscores).
+var validID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 
 // Record represents a completed session's metadata persisted to disk.
 type Record struct {
@@ -60,8 +64,20 @@ func NewStore(dataDir string, logPTY bool, retentionDays int) (*Store, error) {
 // LogPTY returns whether PTY logging is enabled.
 func (s *Store) LogPTY() bool { return s.logPTY }
 
+// validateID checks that an ID is safe for use in file paths.
+func validateID(id string) error {
+	if !validID.MatchString(id) {
+		return fmt.Errorf("invalid session id %q", id)
+	}
+	return nil
+}
+
 // Save writes a session record to disk.
 func (s *Store) Save(r Record) error {
+	if err := validateID(r.ID); err != nil {
+		return err
+	}
+
 	// Compute duration if we have both timestamps.
 	if !r.StoppedAt.IsZero() && !r.CreatedAt.IsZero() {
 		r.Duration = r.StoppedAt.Sub(r.CreatedAt).Truncate(time.Second).String()
@@ -109,6 +125,9 @@ func (s *Store) List() ([]Record, error) {
 
 // Get returns a single session record by ID.
 func (s *Store) Get(id string) (*Record, error) {
+	if err := validateID(id); err != nil {
+		return nil, err
+	}
 	path := filepath.Join(s.dir, id+".json")
 	r, err := s.readRecord(path)
 	if err != nil {
@@ -119,6 +138,9 @@ func (s *Store) Get(id string) (*Record, error) {
 
 // Delete removes a session record and its log file.
 func (s *Store) Delete(id string) error {
+	if err := validateID(id); err != nil {
+		return err
+	}
 	_ = os.Remove(filepath.Join(s.dir, id+".json"))
 	_ = os.Remove(filepath.Join(s.logDir, id+".log"))
 	return nil
@@ -127,6 +149,9 @@ func (s *Store) Delete(id string) error {
 // OpenLogWriter opens a log file for writing PTY output.
 // The caller is responsible for closing the writer.
 func (s *Store) OpenLogWriter(id string) (io.WriteCloser, error) {
+	if err := validateID(id); err != nil {
+		return nil, err
+	}
 	path := filepath.Join(s.logDir, id+".log")
 	f, err := os.Create(path)
 	if err != nil {
@@ -138,6 +163,9 @@ func (s *Store) OpenLogWriter(id string) (io.WriteCloser, error) {
 // ReadLog opens a session's PTY log file for reading.
 // Returns os.ErrNotExist if no log exists.
 func (s *Store) ReadLog(id string) (io.ReadCloser, error) {
+	if err := validateID(id); err != nil {
+		return nil, err
+	}
 	path := filepath.Join(s.logDir, id+".log")
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/sessionlog/store_test.go
+++ b/internal/sessionlog/store_test.go
@@ -1,0 +1,168 @@
+package sessionlog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStoreSaveAndGet(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, false, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := Record{
+		ID:          "abc123",
+		WorkspaceID: "my-ws",
+		Agent:       "claude",
+		Status:      "stopped",
+		CreatedAt:   time.Now().Add(-10 * time.Minute),
+		StoppedAt:   time.Now(),
+	}
+	if err := store.Save(r); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get("abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.WorkspaceID != "my-ws" {
+		t.Errorf("got workspace_id=%q, want my-ws", got.WorkspaceID)
+	}
+	if got.Duration == "" {
+		t.Error("expected duration to be computed")
+	}
+}
+
+func TestStoreList(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, false, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Save two records with different timestamps.
+	r1 := Record{ID: "older", Agent: "shell", Status: "stopped", CreatedAt: time.Now().Add(-2 * time.Hour)}
+	r2 := Record{ID: "newer", Agent: "claude", Status: "stopped", CreatedAt: time.Now().Add(-1 * time.Hour)}
+	_ = store.Save(r1)
+	_ = store.Save(r2)
+
+	records, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("got %d records, want 2", len(records))
+	}
+	// Should be sorted newest first.
+	if records[0].ID != "newer" {
+		t.Errorf("first record should be newer, got %s", records[0].ID)
+	}
+}
+
+func TestStoreDelete(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, true, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := Record{ID: "del-me", Agent: "shell", Status: "stopped", CreatedAt: time.Now()}
+	_ = store.Save(r)
+
+	// Create a log file too.
+	w, err := store.OpenLogWriter("del-me")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.Write([]byte("hello"))
+	_ = w.Close()
+
+	_ = store.Delete("del-me")
+
+	if _, err := store.Get("del-me"); err == nil {
+		t.Error("expected record to be deleted")
+	}
+	if _, err := store.ReadLog("del-me"); err == nil {
+		t.Error("expected log to be deleted")
+	}
+}
+
+func TestStoreCleanup(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, false, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	old := Record{ID: "old", Agent: "shell", Status: "stopped", CreatedAt: time.Now().AddDate(0, 0, -10)}
+	recent := Record{ID: "recent", Agent: "shell", Status: "stopped", CreatedAt: time.Now()}
+	_ = store.Save(old)
+	_ = store.Save(recent)
+
+	removed, err := store.Cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 1 {
+		t.Errorf("expected 1 removed, got %d", removed)
+	}
+
+	records, _ := store.List()
+	if len(records) != 1 || records[0].ID != "recent" {
+		t.Error("expected only recent record to remain")
+	}
+}
+
+func TestStoreLogWriter(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, true, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := store.OpenLogWriter("log-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.Write([]byte("terminal output"))
+	_ = w.Close()
+
+	// Save record — should detect the log file.
+	r := Record{ID: "log-test", Agent: "claude", Status: "stopped", CreatedAt: time.Now()}
+	_ = store.Save(r)
+
+	got, _ := store.Get("log-test")
+	if !got.HasLog {
+		t.Error("expected HasLog=true")
+	}
+
+	rc, err := store.ReadLog("log-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rc.Close() }()
+	data := make([]byte, 100)
+	n, _ := rc.Read(data)
+	if string(data[:n]) != "terminal output" {
+		t.Errorf("got log %q, want 'terminal output'", string(data[:n]))
+	}
+}
+
+func TestNewStoreCreatesDirs(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "path")
+	_, err := NewStore(dir, false, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "sessions")); err != nil {
+		t.Error("sessions dir not created")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "logs")); err != nil {
+		t.Error("logs dir not created")
+	}
+}

--- a/web/src/components/log-viewer.tsx
+++ b/web/src/components/log-viewer.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { api } from "@/lib/api";
+import { Loader2 } from "lucide-react";
+
+interface LogViewerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessionId: string;
+}
+
+export function LogViewer({ open, onOpenChange, sessionId }: LogViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<import("@xterm/xterm").Terminal | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !sessionId) return;
+
+    let mounted = true;
+    setLoading(true);
+
+    async function loadLog() {
+      const [logData, { Terminal }] = await Promise.all([
+        api.getSessionLog(sessionId),
+        import("@xterm/xterm"),
+      ]);
+
+      if (!mounted || !containerRef.current) return;
+
+      // Clean up any existing terminal.
+      if (termRef.current) {
+        termRef.current.dispose();
+      }
+
+      const term = new Terminal({
+        fontSize: 13,
+        fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+        theme: {
+          background: "#09090b",
+          foreground: "#fafafa",
+          cursor: "#09090b", // hide cursor
+        },
+        disableStdin: true,
+        cursorBlink: false,
+        cursorStyle: "bar",
+        scrollback: 50000,
+        convertEol: true,
+      });
+      termRef.current = term;
+      term.open(containerRef.current);
+
+      if (logData) {
+        term.write(logData);
+      } else {
+        term.write("\x1b[2mNo log data available\x1b[0m");
+      }
+
+      setLoading(false);
+    }
+
+    loadLog().catch(() => setLoading(false));
+
+    return () => {
+      mounted = false;
+      if (termRef.current) {
+        termRef.current.dispose();
+        termRef.current = null;
+      }
+    };
+  }, [open, sessionId]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-sm">
+            Session Log — {sessionId.slice(0, 8)}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex-1 relative rounded-md overflow-hidden bg-[#09090b]">
+          {loading && (
+            <div className="absolute inset-0 flex items-center justify-center z-10">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          )}
+          <div ref={containerRef} className="h-full w-full" />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/log-viewer.tsx
+++ b/web/src/components/log-viewer.tsx
@@ -31,11 +31,11 @@ export function LogViewer({ open, onOpenChange, sessionId }: LogViewerProps) {
     setError(null);
 
     async function loadLog() {
-      const [logData, { Terminal }, { FitAddon }, _css] = await Promise.all([
+      const [logData, { Terminal }, { FitAddon }] = await Promise.all([
         api.getSessionLog(sessionId),
         import("@xterm/xterm"),
         import("@xterm/addon-fit"),
-        import("@xterm/xterm/css/xterm.css"),
+        import("@xterm/xterm/css/xterm.css"), // side-effect: loads xterm styles
       ]);
 
       if (!mounted || !containerRef.current) return;

--- a/web/src/components/log-viewer.tsx
+++ b/web/src/components/log-viewer.tsx
@@ -19,18 +19,23 @@ interface LogViewerProps {
 export function LogViewer({ open, onOpenChange, sessionId }: LogViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<import("@xterm/xterm").Terminal | null>(null);
+  const fitRef = useRef<import("@xterm/addon-fit").FitAddon | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open || !sessionId) return;
 
     let mounted = true;
     setLoading(true);
+    setError(null);
 
     async function loadLog() {
-      const [logData, { Terminal }] = await Promise.all([
+      const [logData, { Terminal }, { FitAddon }, _css] = await Promise.all([
         api.getSessionLog(sessionId),
         import("@xterm/xterm"),
+        import("@xterm/addon-fit"),
+        import("@xterm/xterm/css/xterm.css"),
       ]);
 
       if (!mounted || !containerRef.current) return;
@@ -39,6 +44,9 @@ export function LogViewer({ open, onOpenChange, sessionId }: LogViewerProps) {
       if (termRef.current) {
         termRef.current.dispose();
       }
+
+      const fitAddon = new FitAddon();
+      fitRef.current = fitAddon;
 
       const term = new Terminal({
         fontSize: 13,
@@ -54,8 +62,10 @@ export function LogViewer({ open, onOpenChange, sessionId }: LogViewerProps) {
         scrollback: 50000,
         convertEol: true,
       });
+      term.loadAddon(fitAddon);
       termRef.current = term;
       term.open(containerRef.current);
+      fitAddon.fit();
 
       if (logData) {
         term.write(logData);
@@ -66,7 +76,13 @@ export function LogViewer({ open, onOpenChange, sessionId }: LogViewerProps) {
       setLoading(false);
     }
 
-    loadLog().catch(() => setLoading(false));
+    loadLog().catch((err) => {
+      if (mounted) {
+        setError("Failed to load session log");
+        setLoading(false);
+        console.error("Log viewer error:", err);
+      }
+    });
 
     return () => {
       mounted = false;
@@ -74,8 +90,21 @@ export function LogViewer({ open, onOpenChange, sessionId }: LogViewerProps) {
         termRef.current.dispose();
         termRef.current = null;
       }
+      fitRef.current = null;
     };
   }, [open, sessionId]);
+
+  // Re-fit terminal when dialog resizes.
+  useEffect(() => {
+    if (!open) return;
+    const observer = new ResizeObserver(() => {
+      fitRef.current?.fit();
+    });
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+    }
+    return () => observer.disconnect();
+  }, [open]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -89,6 +118,11 @@ export function LogViewer({ open, onOpenChange, sessionId }: LogViewerProps) {
           {loading && (
             <div className="absolute inset-0 flex items-center justify-center z-10">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          )}
+          {error && (
+            <div className="absolute inset-0 flex items-center justify-center z-10 text-sm text-muted-foreground">
+              {error}
             </div>
           )}
           <div ref={containerRef} className="h-full w-full" />

--- a/web/src/components/rename-dialog.tsx
+++ b/web/src/components/rename-dialog.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+const VALID_WORKSPACE_ID = /^[a-z0-9][a-z0-9_-]*$/;
+
+interface RenameDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentName: string;
+  onConfirm: (newName: string) => void;
+}
+
+export function RenameDialog({
+  open,
+  onOpenChange,
+  currentName,
+  onConfirm,
+}: RenameDialogProps) {
+  const [name, setName] = useState(currentName);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setName(currentName);
+      setError("");
+    }
+  }, [open, currentName]);
+
+  const validate = (value: string) => {
+    if (!value) return "Name is required";
+    if (!VALID_WORKSPACE_ID.test(value))
+      return "Must be lowercase alphanumeric, hyphens, or underscores";
+    if (value === currentName) return "Name is unchanged";
+    return "";
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const err = validate(name);
+    if (err) {
+      setError(err);
+      return;
+    }
+    onConfirm(name);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Rename workspace</DialogTitle>
+            <DialogDescription>
+              Enter a new name for <span className="font-mono">{currentName}</span>.
+              Volume data will be preserved.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-4 space-y-2">
+            <Label htmlFor="workspace-name">Workspace name</Label>
+            <Input
+              id="workspace-name"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value.toLowerCase());
+                setError("");
+              }}
+              placeholder="my-workspace"
+              autoFocus
+            />
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!!validate(name)}>
+              Rename
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/rename-dialog.tsx
+++ b/web/src/components/rename-dialog.tsx
@@ -40,6 +40,7 @@ export function RenameDialog({
 
   const validate = (value: string) => {
     if (!value) return "Name is required";
+    if (value.length > 128) return "Name must be 128 characters or less";
     if (!VALID_WORKSPACE_ID.test(value))
       return "Must be lowercase alphanumeric, hyphens, or underscores";
     if (value === currentName) return "Name is unchanged";

--- a/web/src/components/session-history.tsx
+++ b/web/src/components/session-history.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { api } from "@/lib/api";
+import type { SessionRecord } from "@/lib/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { LogViewer } from "./log-viewer";
+import { Clock, FileText, Trash2, History } from "lucide-react";
+import { toast } from "sonner";
+
+export function SessionHistory() {
+  const [records, setRecords] = useState<SessionRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [logTarget, setLogTarget] = useState<string | null>(null);
+
+  const fetchHistory = useCallback(async () => {
+    try {
+      const data = await api.listSessionHistory();
+      setRecords(data || []);
+    } catch {
+      // Session history endpoint may not exist on older servers.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      await api.deleteSessionHistory(id);
+      setRecords((prev) => prev.filter((r) => r.id !== id));
+      toast.success("History entry removed");
+    } catch {
+      toast.error("Failed to remove history entry");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        {[...Array(2)].map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  if (records.length === 0) return null;
+
+  return (
+    <div>
+      <h3 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
+        <History className="h-3.5 w-3.5" />
+        Session History
+      </h3>
+      <div className="space-y-2">
+        {records.map((r) => (
+          <div
+            key={r.id}
+            className="flex items-center justify-between gap-3 p-3 rounded-lg border border-border bg-card"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 mb-0.5">
+                <span className="font-medium text-sm truncate">
+                  {r.workspace_id || r.id.slice(0, 8)}
+                </span>
+                <Badge variant="outline" className="text-xs">
+                  {r.status}
+                </Badge>
+                {r.error && (
+                  <Badge variant="destructive" className="text-xs">
+                    error
+                  </Badge>
+                )}
+              </div>
+              <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                <span className="font-mono bg-muted/50 px-1.5 py-0.5 rounded">
+                  {r.agent}
+                </span>
+                {r.duration && (
+                  <span className="flex items-center gap-1">
+                    <Clock className="h-3 w-3" />
+                    {r.duration}
+                  </span>
+                )}
+                <span>
+                  {new Date(r.created_at).toLocaleDateString()}{" "}
+                  {new Date(r.created_at).toLocaleTimeString([], {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </span>
+              </div>
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              {r.has_log && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => setLogTarget(r.id)}
+                  title="View log"
+                >
+                  <FileText className="h-3.5 w-3.5" />
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-destructive hover:text-destructive"
+                onClick={() => handleDelete(r.id)}
+                title="Delete"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <LogViewer
+        open={logTarget !== null}
+        onOpenChange={(open) => !open && setLogTarget(null)}
+        sessionId={logTarget || ""}
+      />
+    </div>
+  );
+}

--- a/web/src/components/workspace-card.tsx
+++ b/web/src/components/workspace-card.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { MoreVertical, ExternalLink, Square, Trash2, Play } from "lucide-react";
+import { MoreVertical, ExternalLink, Square, Trash2, Play, Pencil } from "lucide-react";
 import type { Session } from "@/lib/types";
 
 const statusConfig: Record<
@@ -39,9 +39,10 @@ interface WorkspaceCardProps {
   onStop: (id: string) => void;
   onRestart: (id: string) => void;
   onDelete: (id: string) => void;
+  onRename?: (workspaceId: string) => void;
 }
 
-export function WorkspaceCard({ session, onStop, onRestart, onDelete }: WorkspaceCardProps) {
+export function WorkspaceCard({ session, onStop, onRestart, onDelete, onRename }: WorkspaceCardProps) {
   const status = statusConfig[session.status] || statusConfig.stopped;
   const isRunning = session.status === "running";
   const isStopped = session.status === "stopped";
@@ -115,6 +116,12 @@ export function WorkspaceCard({ session, onStop, onRestart, onDelete }: Workspac
                   <DropdownMenuItem onClick={() => onStop(session.id)}>
                     <Square className="h-4 w-4 mr-2" />
                     Stop
+                  </DropdownMenuItem>
+                )}
+                {isStopped && onRename && session.spec.workspace_id && (
+                  <DropdownMenuItem onClick={() => onRename(session.spec.workspace_id!)}>
+                    <Pencil className="h-4 w-4 mr-2" />
+                    Rename
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuSeparator />

--- a/web/src/components/workspace-list.tsx
+++ b/web/src/components/workspace-list.tsx
@@ -133,7 +133,7 @@ export function WorkspaceList({
     try {
       await api.renameWorkspace(oldId, newId);
       setRenameTarget(null);
-      fetchData();
+      await fetchData();
       toast.success("Workspace renamed", { id: "rename" });
     } catch (err) {
       toast.error(

--- a/web/src/components/workspace-list.tsx
+++ b/web/src/components/workspace-list.tsx
@@ -18,7 +18,9 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "./confirm-dialog";
-import { Search, Inbox, Play, Trash2, HardDrive, Loader2 } from "lucide-react";
+import { RenameDialog } from "./rename-dialog";
+import { SessionHistory } from "./session-history";
+import { Search, Inbox, Play, Trash2, HardDrive, Loader2, Pencil } from "lucide-react";
 import { toast } from "sonner";
 
 export function WorkspaceList({
@@ -37,6 +39,7 @@ export function WorkspaceList({
     id: string;
   } | null>(null);
   const [resumingId, setResumingId] = useState<string | null>(null);
+  const [renameTarget, setRenameTarget] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
     try {
@@ -122,6 +125,21 @@ export function WorkspaceList({
       toast.success("Workspace deleted");
     } catch (err) {
       toast.error("Failed to delete workspace");
+    }
+  };
+
+  const handleRename = async (oldId: string, newId: string) => {
+    toast.loading("Renaming workspace...", { id: "rename" });
+    try {
+      await api.renameWorkspace(oldId, newId);
+      setRenameTarget(null);
+      fetchData();
+      toast.success("Workspace renamed", { id: "rename" });
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to rename workspace",
+        { id: "rename" }
+      );
     }
   };
 
@@ -224,6 +242,7 @@ export function WorkspaceList({
                   onStop={(id) => setConfirmAction({ type: "stop", id })}
                   onRestart={handleRestart}
                   onDelete={(id) => setConfirmAction({ type: "delete", id })}
+                  onRename={(wsId) => setRenameTarget(wsId)}
                 />
               ))}
             </div>
@@ -278,6 +297,14 @@ export function WorkspaceList({
                           <Button
                             variant="ghost"
                             size="icon"
+                            className="h-8 w-8"
+                            onClick={() => setRenameTarget(ws.id)}
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
                             className="h-8 w-8 text-destructive hover:text-destructive"
                             onClick={() => handleDeleteWorkspace(ws.id)}
                           >
@@ -291,6 +318,9 @@ export function WorkspaceList({
               </div>
             </div>
           )}
+
+          {/* Session history */}
+          {statusFilter === "all" && <SessionHistory />}
         </>
       )}
 
@@ -315,6 +345,14 @@ export function WorkspaceList({
         onConfirm={() => {
           if (confirmAction) handleDelete(confirmAction.id);
           setConfirmAction(null);
+        }}
+      />
+      <RenameDialog
+        open={renameTarget !== null}
+        onOpenChange={(open) => !open && setRenameTarget(null)}
+        currentName={renameTarget || ""}
+        onConfirm={(newName) => {
+          if (renameTarget) handleRename(renameTarget, newName);
         }}
       />
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   Session,
   SessionSpec,
+  SessionRecord,
   ContainerStats,
   SystemInfo,
   Workspace,
@@ -69,8 +70,30 @@ export const api = {
 
   // Workspaces
   listWorkspaces: () => fetchJSON<Workspace[]>("/workspaces"),
+  renameWorkspace: (oldId: string, newId: string) =>
+    fetchJSON<{ id: string }>(`/workspaces/${oldId}`, {
+      method: "PUT",
+      body: JSON.stringify({ id: newId }),
+    }),
   deleteWorkspace: (id: string) =>
     fetchJSON<void>(`/workspaces/${id}`, { method: "DELETE" }),
+
+  // Session history
+  listSessionHistory: (params?: { workspace_id?: string }) => {
+    const qs = params?.workspace_id
+      ? `?workspace_id=${encodeURIComponent(params.workspace_id)}`
+      : "";
+    return fetchJSON<SessionRecord[]>(`/sessions/history${qs}`);
+  },
+  getSessionLog: async (id: string) => {
+    const res = await fetch(
+      `${API_BASE}/sessions/history/${id}/log`
+    );
+    if (!res.ok) return null;
+    return res.text();
+  },
+  deleteSessionHistory: (id: string) =>
+    fetchJSON<void>(`/sessions/history/${id}`, { method: "DELETE" }),
 
   // WebSocket URL for session stream
   streamURL: (sessionId: string) => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -51,3 +51,18 @@ export interface Workspace {
   image?: string;
   agent?: string;
 }
+
+export interface SessionRecord {
+  id: string;
+  workspace_id?: string;
+  agent: string;
+  image?: string;
+  repo_url?: string;
+  branch?: string;
+  status: string;
+  created_at: string;
+  stopped_at?: string;
+  duration?: string;
+  error?: string;
+  has_log: boolean;
+}


### PR DESCRIPTION
## Summary
- **Workspace rename** — `PUT /workspaces/{id}` renames Docker volumes and committed images; rename dialog in dashboard
- **Session history** — persists session metadata to disk with optional PTY log capture; history panel + log viewer in dashboard
- Configurable via `ZYNQEL_LOG_PTY=true` and `ZYNQEL_LOG_RETENTION_DAYS=30`

Closes #50, closes #51

## Test plan
- [ ] Create workspace, stop it, rename via dashboard — verify volume data preserved
- [ ] Attempt rename of running workspace — expect 409 error
- [ ] Attempt rename to existing name — expect 409 error
- [ ] Run session, stop it — verify history record appears in dashboard
- [ ] Enable `ZYNQEL_LOG_PTY=true`, run session — verify PTY log viewable in log viewer
- [ ] `go test -race ./...` passes
- [ ] `golangci-lint run ./...` passes