### PR TITLE
[ZYNQ-66] bug: websocket replay may leak partial ANSI/OSC escape sequences after refresh

### DIFF
--- a/internal/server/ws.go
+++ b/internal/server/ws.go
@@ -92,6 +92,7 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 	sendWSJSON(conn, &wsMu, "session.state", string(sess.Status))
 
 	// Send buffered replay (reconnect support).
+	replay = alignReplayToLineStart(replay)
 	if len(replay) > 0 {
 		encoded := base64.StdEncoding.EncodeToString(replay)
 		sendWSJSON(conn, &wsMu, "pty.output", encoded)
@@ -201,6 +202,29 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 			log.Printf("unknown message type: %s", msg.Type)
 		}
 	}
+}
+
+// alignReplayToLineStart trims leading bytes up to the first line boundary when
+// replay begins mid-line (common with ring-buffer reconnect replay). This avoids
+// rendering partial ANSI/OSC escape fragments as visible text after refresh.
+func alignReplayToLineStart(replay []byte) []byte {
+	if len(replay) == 0 {
+		return replay
+	}
+	if replay[0] == '\n' || replay[0] == '\r' {
+		return replay
+	}
+
+	for i, b := range replay {
+		if b == '\n' || b == '\r' {
+			if i+1 >= len(replay) {
+				return nil
+			}
+			return replay[i+1:]
+		}
+	}
+	// No full line boundary in buffer: skip replay to avoid leaking fragments.
+	return nil
 }
 
 // sendWSJSON sends a typed JSON message over the WebSocket connection.

--- a/internal/server/ws_replay_test.go
+++ b/internal/server/ws_replay_test.go
@@ -1,0 +1,50 @@
+package server
+
+import "testing"
+
+func TestAlignReplayToLineStart(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "already line start",
+			in:   "\n$ ls\nfile\n",
+			want: "\n$ ls\nfile\n",
+		},
+		{
+			name: "trim partial prefix at newline",
+			in:   "11;rgb:aaaa/bbbb/cccc\n/workspace $ ls\n",
+			want: "/workspace $ ls\n",
+		},
+		{
+			name: "trim partial prefix at carriage return",
+			in:   "garbage prefix\rprompt$ ",
+			want: "prompt$ ",
+		},
+		{
+			name: "no line boundary drops replay",
+			in:   "partial_escape_without_newline",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := alignReplayToLineStart([]byte(tt.in))
+			if string(got) != tt.want {
+				t.Fatalf("alignReplayToLineStart() = %q, want %q", string(got), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- bug: websocket replay may leak partial ANSI/OSC escape sequences after refresh

## Validation
- [ ] `go build ./...`
- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] local verification completed

## Linked
- Closes #66

## Project
- [ ] Project item is linked
- [ ] Status is `In Progress` while review is open
